### PR TITLE
Install flake8 in GitHub Actions workflow

### DIFF
--- a/electron-react-app/.github/workflows/python-environment-setup.yml
+++ b/electron-react-app/.github/workflows/python-environment-setup.yml
@@ -23,6 +23,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Install flake8
+        run: |
+          pip install flake8
+
       - name: Create and activate virtual environment
         run: |
           python -m venv venv


### PR DESCRIPTION
Adds a step to explicitly install flake8 in the GitHub Actions workflow for the `electron-react-app` project to ensure the flake8 command is available for linting.

- **Installation Step**: Installs flake8 using pip after dependencies installation but before any linting steps or test script executions. This ensures flake8 is available in the GitHub Actions runner environment, addressing the issue where the flake8 command could not be found.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nate-dryer/llama-fs?shareId=e4f61351-09b4-4c94-8a28-8bb45dfa1ec2).